### PR TITLE
Potential fix for code scanning alert no. 3: Clear-text logging of sensitive information

### DIFF
--- a/gallery-service/main.go
+++ b/gallery-service/main.go
@@ -641,7 +641,7 @@ func authnMiddleware(next http.Handler) http.Handler {
 
 		if strings.HasPrefix(authz, "Bearer") {
 			tokenString := strings.TrimSpace(strings.TrimPrefix(authz, "Bearer"))
-			log.Printf("AuthN: Received bearer token %s", tokenString)
+			log.Printf("AuthN: Received bearer token")
 			token, err := jwt.ParseWithClaims(tokenString, &OctoClaims{}, func(token *jwt.Token) (interface{}, error) {
 				// Don't forget to validate the alg is what you expect:
 				//if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
@@ -660,7 +660,7 @@ func authnMiddleware(next http.Handler) http.Handler {
 			
 			
 			if claims, ok := token.Claims.(*OctoClaims); ok && token.Valid {
-				log.Printf("AuthN: Received valid token %s", authz)
+				log.Printf("AuthN: Received valid token")
 
 				log.Printf("AuthN: Adding %s %s", GitHubLoginHeader, claims.Profile.Login)
 				r.Header.Add(GitHubLoginHeader.String(), claims.Profile.Login)


### PR DESCRIPTION
Potential fix for [https://github.com/saurang1984/ghas-bootcamp/security/code-scanning/3](https://github.com/saurang1984/ghas-bootcamp/security/code-scanning/3)

To fix the problem, we should avoid logging the sensitive `Authorization` header value directly. Instead, we can log a generic message indicating that an authorization token was received without including the actual token. This approach maintains the functionality of logging the event without exposing sensitive information.

- Replace the logging of the `authz` variable with a generic message.
- Ensure that no sensitive information is logged in clear text.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
